### PR TITLE
Update .NET sample container usage

### DIFF
--- a/deploymenttest.yaml
+++ b/deploymenttest.yaml
@@ -11,13 +11,13 @@ spec:
     spec:
       containers:
       - name: aspnetapp
-        image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         readinessProbe:
           httpGet:
             path: /
-            port: 80
+            port: 8080
           periodSeconds: 3
           timeoutSeconds: 1

--- a/sample.yaml
+++ b/sample.yaml
@@ -6,10 +6,10 @@ metadata:
     app: test-agic-app
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
-    - containerPort: 80
+    - containerPort: 8080
       protocol: TCP
 ---
 apiVersion: v1


### PR DESCRIPTION
* The `core` repo is obsolete. See https://github.com/dotnet/dotnet-docker/discussions/3667
* The default port of the sample container is now 8080. See https://learn.microsoft.com/dotnet/core/compatibility/containers/8.0/aspnet-port